### PR TITLE
Nullable type support

### DIFF
--- a/package/src/Types.res
+++ b/package/src/Types.res
@@ -1,31 +1,29 @@
 module GraphSchema = {
-  type schemaValue = {
-    value: string
-  }
-  type graphSchemaDataTypes = [  | #String
-  | #Int
-  | #BigInt
-  | #Address
-  | #Bytes
-  | #Boolean
-  | #BigDecimal]
-  type schemaValueType = {
-    value: graphSchemaDataTypes
-  }
-  type entityFieldTypeKind = [  | #NonNullType
-  | #ListType
-  | #NamedType]
+  type schemaValue = {value: string}
+  type graphSchemaDataTypes = [
+    | #String
+    | #Int
+    | #BigInt
+    | #Address
+    | #Bytes
+    | #Boolean
+    | #BigDecimal
+  ]
+  type schemaValueType = {value: graphSchemaDataTypes}
+  type entityFieldTypeKind = [
+    | #NonNullType
+    | #ListType
+    | #NamedType
+  ]
   type rec entityFieldType = {
     kind: entityFieldTypeKind,
     name: schemaValueType,
-    @as("type") _type: option<entityFieldType>
+    @as("type") _type: option<entityFieldType>,
   }
-  type schemaLabel = {
-    name: schemaValue,
-  }
+  type schemaLabel = {name: schemaValue}
   type entityField = {
     name: schemaValue,
-     @as("type") _type: entityFieldType,
-    directives: array<schemaLabel>
+    @as("type") _type: entityFieldType,
+    directives: array<schemaLabel>,
   }
 }


### PR DESCRIPTION
Introduced nullable fields in the code generator, so
```gql
field: String
```
in the schema will turn into
```ts
field: String | null
```
in the generated ts file.